### PR TITLE
Fix linting error in the output terraform component

### DIFF
--- a/lab-azure-resource/components/lab/output.tf
+++ b/lab-azure-resource/components/lab/output.tf
@@ -1,14 +1,14 @@
 output "lab_rg_name" {
   description = "The auto generated resource group name"
-  value = azurerm_resource_group.res-0.name
+  value       = azurerm_resource_group.res-0.name
 }
 
 output "lab_vnet_name" {
   description = "The auto generated resource vnet name"
-  value = azurerm_virtual_network.res-8.name
+  value       = azurerm_virtual_network.res-8.name
 }
 
 output "lab_vnet_cidr" {
   description = "The vnet address space"
-  value = azurerm_virtual_network.res-8.address_space
+  value       = azurerm_virtual_network.res-8.address_space
 }


### PR DESCRIPTION
### Jira link

N/A

### Change description

One of the components "output.tf" has a linting error which fails Pester tests during pipeline pre-check.
This MR fixes the linting error so anyone new going through the Golden Path tutorial can complete this part successfully.

### Testing done

With these changes pesters tests and the the precheck step in my pipeline pass fine.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] (NA) README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
