### PR TITLE
Fix broken links to lab resources folder and tech docs page

### DIFF
--- a/source/Walkthrough/index.html.md.erb
+++ b/source/Walkthrough/index.html.md.erb
@@ -17,7 +17,7 @@ The architecture diagram below represents core areas within Platform Operations.
   <img alt="PlatOps Core Architecture" src="./images/golden-path.png" width="auto">
 </details>
 
-At the end of the hands-on exercises, you can read up on the [technical documents](./Technical Documentation) for some more details on the core technologies
+At the end of the hands-on exercises, you can read up on the [technical documents](https://tools.hmcts.net/confluence/display/DTSPO/Technical+Documentation) for some more details on the core technologies
 to help solidify the knowledge gained.
 
 <div class="nav">

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -46,7 +46,7 @@ At the end of this exercise you would have been introduced to the following tech
 You will have a feel of the HMCTS landscape to help you navigate your way through your epics and tasks.
 
 #### GoldenPath HandsOs - Code samples
-Code for the Azure [Virtual Networks](/Walkthrough/virtual-networks.html) section labs can be found in the [labs resource](https://github.com/hmcts/goldenpath-platops/lab-azure-resource) folder
+Code for the Azure [Virtual Networks](/Walkthrough/virtual-networks.html) section labs can be found in the [labs resource](https://github.com/hmcts/goldenpath-platops/tree/master/lab-azure-resource) folder
 
 ### Feedback
 We would appreciate your feedback at the end of this exercise. This would help us improve


### PR DESCRIPTION
### Jira link

N/S

### Change description

- Fix broken link to lab resources folder in github
- Fix broken link to technical documentation page which has been removed form this repo and seems to live on Confluence instead

### Testing done

I tested that the new links work

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] (N/A) tests have been updated / new tests has been added (if needed)
- [ ] (NO) Does this PR introduce a breaking change
