### PR TITLE
Replace deprecated skip_provider_registration property

### DIFF
--- a/lab-azure-resource/components/lab/provider.tf
+++ b/lab-azure-resource/components/lab/provider.tf
@@ -9,22 +9,22 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
-  subscription_id            = var.subscription_id
-  skip_provider_registration = "true"
+  subscription_id                 = var.subscription_id
+  resource_provider_registrations = "none"
   features {}
   alias = "labs"
 }
 
 provider "azurerm" {
-  subscription_id            = var.hub_sbox_subscription_id
-  skip_provider_registration = "true"
+  subscription_id                 = var.hub_sbox_subscription_id
+  resource_provider_registrations = "none"
   features {}
   alias = "hub-sbox"
 }
 
 provider "azurerm" {
-  subscription_id            = "ed302caf-ec27-4c64-a05e-85731c3ce90e" # Update current VPN subscription id if this no longer exists
-  skip_provider_registration = "true"
+  subscription_id                 = "ed302caf-ec27-4c64-a05e-85731c3ce90e" # Update current VPN subscription id if this no longer exists
+  resource_provider_registrations = "none"
   features {}
   alias = "vpn"
 }

--- a/source/Walkthrough/virtual-networks.html.md.erb
+++ b/source/Walkthrough/virtual-networks.html.md.erb
@@ -105,7 +105,7 @@ Navigate to [02-addresses-sbox.tf](https://github.com/hmcts/hub-panorama-terrafo
 
 The value should be the cidr address space of your vnet
 
-Next navigate to the [sandbox policy rules](https://github.com/hmcts/hub-panorama-terraform/blob/master/components/configuration/groups/policies/security-policy-rules/02-security-profiles.tf) file and
+Next navigate to the [04-policy-rules-sbox.tf](https://github.com/hmcts/hub-panorama-terraform/blob/master/components/configuration/groups/policies/security-policy-rules/04-policy-rules-sbox.tf) file and
 create a new security policy with the following details
 
 ```json


### PR DESCRIPTION
### Jira link
N/A
### Change description

Replace `skip_provider_registration` deprecated property which was used to skip full 68 provider registration by Terraform.
Newer Terraform versions replaced this with `resource_provider_registrations` which has 5 different registration modes as recommended by Microsoft.
Statement `resource_provider_registrations="none"` is equivalent to previous `skip_provider_registration="true"` - it means no resource providers are registered.

For more details read: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide?product_intent=terraform#improved-resource-provider-registration

### Testing done

I tested this change by implementing it in my lab Terraform which is based on this repo and running the pipeline successfully:
https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=711337&view=results

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] (N/A) README and other documentation has been updated / added (if needed)
- [ ] (N/A) tests have been updated / new tests has been added (if needed)
- [ ] (NO) Does this PR introduce a breaking change
